### PR TITLE
Add Azure DevOps functionality for maintenance help while looking at work items

### DIFF
--- a/azdo-helpers.js
+++ b/azdo-helpers.js
@@ -65,8 +65,8 @@
     //     Work item page: https://{organization}.visualstudio.com/{project}/_workitems/edit/{work-item-number}
     //     List page: {organization}.visualstudio.com/{project}/_queries/query/{query-guid}/
     let getWorkItemData = function () {
-        let workItemId = document.querySelectorAll("span[aria-label='ID Field']")[0].textContent;
-        let workItemUrl = document.querySelectorAll(".work-item-form a.caption")[0].href;
+        let workItemId = document.querySelectorAll("span[aria-label='ID Field']")[0]?.textContent;
+        let workItemUrl = document.querySelectorAll(".work-item-form a.caption")[0]?.href;
 
         // let workItemForm = document.getElementsByClassName("work-item-form")[0];
         // let workItemControls = workItemForm?.getElementsByClassName("control");

--- a/azdo-helpers.js
+++ b/azdo-helpers.js
@@ -1,76 +1,69 @@
 // NOTE: Had to stuff everything in this immediately executing function to avoid duplicate declaration errors when this script was run every time the pop-up was loaded. Probably a better way to handle this, though.
 (async function () {
-    console.log("Loaded azdo-helpers.js");
-    // function delay(ms) {
-    //     return new Promise(resolve => setTimeout(resolve, ms));
-    // }
-    // let storageLocalGetAsync = function (keys) {
-    //     // TODO: Add some sort of expiration logic to set/get.
-    //     let gotValue = new Promise((resolve, reject) => {
-    //         chrome.storage.local.get(
-    //             keys, // NOTE: `null` will get entire contents of storage
-    //             function (result) {
-    //                 // Keys could be a string or an array of strings (or any object to get back an empty result, or null to get all of cache).
-    //                 // Unify to an array regardless.
-    //                 let keyList = Array.isArray(keys) ? [...keys] : [keys];
-    //                 for (var keyIndex in keyList) {
-    //                     var key = keyList[keyIndex];
-    //                     if (result[key]) {
-    //                         console.log({status: `Cache found: [${key}]`, keys, result });
-    //                     }
-    //                     else {
-    //                         console.log({status: `Cache miss: [${key}]`, keys });
-    //                     }
-    //                 }
-    //                 resolve(result);
-    //             }
-    //         );
-    //     });
-    //     return gotValue;
-    // };
-    // let storageLocalSetAsync = function (items) {
-    //     // TODO: Add some sort of expiration logic to set/get.
-    //     let setValue = new Promise((resolve, reject) => {
-    //         chrome.storage.local.set(
-    //             items,
-    //             function () {
-    //                 // If this cache call fails, Chrome will have set `runtime.lastError`.
-    //                 if (chrome.runtime.lastError) {
-    //                     reject(new Error(chrome.runtime.lastError.message || `Cache set error: ${chrome.runtime.lastError}`));
-    //                 }
-    //                 else {
-    //                     resolve();
-    //                 }
-    //             }
-    //         );
-    //     });
-    //     return setValue;
-    // };
-    // let storageLocalRemoveAsync = async function (keys) {
-    //     let removeValue = new Promise((resolve, reject) => {
-    //         chrome.storage.local.remove(
-    //             keys,
-    //             function () {
-    //                 // If this cache call fails, Chrome will have set `runtime.lastError`.
-    //                 if (chrome.runtime.lastError) {
-    //                     reject(new Error(chrome.runtime.lastError.message || `Error retrieving cache: ${chrome.runtime.lastError}`));
-    //                 }
-    //                 else {
-    //                     resolve();
-    //                 }
-    //             }
-    //         );
-    //     });
-    // };
+    let storageLocalGetAsync = function (keys) {
+        // TODO: Add some sort of expiration logic to set/get.
+        let gotValue = new Promise((resolve, reject) => {
+            chrome.storage.local.get(
+                keys, // NOTE: `null` will get entire contents of storage
+                function (result) {
+                    // Keys could be a string or an array of strings (or any object to get back an empty result, or null to get all of cache).
+                    // Unify to an array regardless.
+                    let keyList = Array.isArray(keys) ? [...keys] : [keys];
+                    for (var keyIndex in keyList) {
+                        var key = keyList[keyIndex];
+                        if (result[key]) {
+                            console.log({status: `Cache found: [${key}]`, keys, result });
+                        }
+                        else {
+                            console.log({status: `Cache miss: [${key}]`, keys });
+                        }
+                    }
+                    resolve(result);
+                }
+            );
+        });
+        return gotValue;
+    };
+    let storageLocalSetAsync = function (items) {
+        // TODO: Add some sort of expiration logic to set/get.
+        let setValue = new Promise((resolve, reject) => {
+            chrome.storage.local.set(
+                items,
+                function () {
+                    // If this cache call fails, Chrome will have set `runtime.lastError`.
+                    if (chrome.runtime.lastError) {
+                        reject(new Error(chrome.runtime.lastError.message || `Cache set error: ${chrome.runtime.lastError}`));
+                    }
+                    else {
+                        resolve();
+                    }
+                }
+            );
+        });
+        return setValue;
+    };
+    let storageLocalRemoveAsync = async function (keys) {
+        let removeValue = new Promise((resolve, reject) => {
+            chrome.storage.local.remove(
+                keys,
+                function () {
+                    // If this cache call fails, Chrome will have set `runtime.lastError`.
+                    if (chrome.runtime.lastError) {
+                        reject(new Error(chrome.runtime.lastError.message || `Error retrieving cache: ${chrome.runtime.lastError}`));
+                    }
+                    else {
+                        resolve();
+                    }
+                }
+            );
+        });
+    };
 
-    // // storageLocalRemoveAsync([ location ]);
+    // storageLocalRemoveAsync([ location ]);
 
-    // TODO: Check page for work item
+    // Check page for work item
     //     Work item page: https://{organization}.visualstudio.com/{project}/_workitems/edit/{work-item-number}
     //     List page: {organization}.visualstudio.com/{project}/_queries/query/{query-guid}/
-    //     On list page: div.work-item-form-container > .work-item-form
-    //     On item page: div.work-item-form > .work-item-view
-    //     .work-item-form
     let getWorkItemData = function () {
         let workItemId = document.querySelectorAll("span[aria-label='ID Field']")[0].textContent;
         let workItemUrl = document.querySelectorAll(".work-item-form a.caption")[0].href;
@@ -108,29 +101,11 @@
             ...fieldsAndValuesAsObject
         };
     };
-    let workItemData = getWorkItemData();
-    console.log(workItemData);
-    // TODO: Get similar work items via AzDO query URL
-    // TODO: Offer link to unit page per URL property
 
-    //     return {
-    //         msAuthorMetaTagValue: msAuthor,
-    //         gitHubAuthorMetaTagValue: author,
-    //         msDateMetaTagValue: msDate,
-    //         gitHubYamlLocation: gitUrlValues.gitYamlEditUrl,
-    //         gitHubMarkdownLocation: gitUrlValues.gitMarkdownEditUrl,
-    //     };
-    // };
-    // let cachePageMetadata = async function (location, pageMetadata) {
-    //     pageMetadata = getCurrentPageMetadata();
-    //     let cacheAddition = {};
-    //     cacheAddition[location] = pageMetadata;
-    //     await storageLocalSetAsync(cacheAddition);
-    // };
-    let sendUpdateRequest = function (workItemData) {
+    let sendPopUpUpdateRequest = function (workItemData) {
         chrome.runtime.sendMessage(
             {
-                method: 'workItemCollected',
+                method: "workItemCollected",
                 data: workItemData
             },
             function (response) {
@@ -144,29 +119,8 @@
         );
     };
 
-    // let workItemId = document.location.href;
+    let workItemData = getWorkItemData();
+    console.log(workItemData);
 
-    // var pageMetadata = await (async function () {
-    //     var cachedMetadata = await storageLocalGetAsync([ location ]);
-    //     return cachedMetadata[location];
-    // })();
-    // var wasPageMetadataCached = false;
-
-    // if (!pageMetadata) {
-    //     pageMetadata = getCurrentPageMetadata();
-    //     cachePageMetadata(location, pageMetadata);
-    // }
-    // else {
-    //     wasPageMetadataCached = true;
-    // }
-
-    sendUpdateRequest(workItemData);
-
-    // if (wasPageMetadataCached) {
-    //     // Get the latest from the page and re-cache it.
-    //     await delay(5000);
-    //     pageMetadata = getCurrentPageMetadata();
-    //     cachePageMetadata(location, pageMetadata);
-    //     sendUpdateRequest(pageMetadata);
-    // }
+    sendPopUpUpdateRequest(workItemData);
 })();

--- a/azdo-helpers.js
+++ b/azdo-helpers.js
@@ -1,0 +1,172 @@
+// NOTE: Had to stuff everything in this immediately executing function to avoid duplicate declaration errors when this script was run every time the pop-up was loaded. Probably a better way to handle this, though.
+(async function () {
+    console.log("Loaded azdo-helpers.js");
+    // function delay(ms) {
+    //     return new Promise(resolve => setTimeout(resolve, ms));
+    // }
+    // let storageLocalGetAsync = function (keys) {
+    //     // TODO: Add some sort of expiration logic to set/get.
+    //     let gotValue = new Promise((resolve, reject) => {
+    //         chrome.storage.local.get(
+    //             keys, // NOTE: `null` will get entire contents of storage
+    //             function (result) {
+    //                 // Keys could be a string or an array of strings (or any object to get back an empty result, or null to get all of cache).
+    //                 // Unify to an array regardless.
+    //                 let keyList = Array.isArray(keys) ? [...keys] : [keys];
+    //                 for (var keyIndex in keyList) {
+    //                     var key = keyList[keyIndex];
+    //                     if (result[key]) {
+    //                         console.log({status: `Cache found: [${key}]`, keys, result });
+    //                     }
+    //                     else {
+    //                         console.log({status: `Cache miss: [${key}]`, keys });
+    //                     }
+    //                 }
+    //                 resolve(result);
+    //             }
+    //         );
+    //     });
+    //     return gotValue;
+    // };
+    // let storageLocalSetAsync = function (items) {
+    //     // TODO: Add some sort of expiration logic to set/get.
+    //     let setValue = new Promise((resolve, reject) => {
+    //         chrome.storage.local.set(
+    //             items,
+    //             function () {
+    //                 // If this cache call fails, Chrome will have set `runtime.lastError`.
+    //                 if (chrome.runtime.lastError) {
+    //                     reject(new Error(chrome.runtime.lastError.message || `Cache set error: ${chrome.runtime.lastError}`));
+    //                 }
+    //                 else {
+    //                     resolve();
+    //                 }
+    //             }
+    //         );
+    //     });
+    //     return setValue;
+    // };
+    // let storageLocalRemoveAsync = async function (keys) {
+    //     let removeValue = new Promise((resolve, reject) => {
+    //         chrome.storage.local.remove(
+    //             keys,
+    //             function () {
+    //                 // If this cache call fails, Chrome will have set `runtime.lastError`.
+    //                 if (chrome.runtime.lastError) {
+    //                     reject(new Error(chrome.runtime.lastError.message || `Error retrieving cache: ${chrome.runtime.lastError}`));
+    //                 }
+    //                 else {
+    //                     resolve();
+    //                 }
+    //             }
+    //         );
+    //     });
+    // };
+
+    // // storageLocalRemoveAsync([ location ]);
+
+    // TODO: Check page for work item
+    //     Work item page: https://{organization}.visualstudio.com/{project}/_workitems/edit/{work-item-number}
+    //     List page: {organization}.visualstudio.com/{project}/_queries/query/{query-guid}/
+    //     On list page: div.work-item-form-container > .work-item-form
+    //     On item page: div.work-item-form > .work-item-view
+    //     .work-item-form
+    let getWorkItemData = function () {
+        let workItemId = document.querySelectorAll("span[aria-label='ID Field']")[0].textContent;
+        let workItemUrl = document.querySelectorAll(".work-item-form a.caption")[0].href;
+
+        // let workItemForm = document.getElementsByClassName("work-item-form")[0];
+        // let workItemControls = workItemForm?.getElementsByClassName("control");
+        let workItemControls = document.querySelectorAll(".work-item-form .control");
+        let fieldsAndValues = [...workItemControls].map((control) => {
+            let labelControl = control.getElementsByClassName("workitemcontrol-label")[0];
+            let inputControl = control.getElementsByTagName("input")[0];
+            if (labelControl && inputControl) {
+                let entry = {
+                    label: labelControl.textContent,
+                    value: inputControl.value,
+                };
+                // console.log(entry);
+                return entry;
+            }
+            else {
+                console.log({ "msg": "No label or input", control });
+            }
+        });
+        let fieldsAndValuesAsObject = fieldsAndValues.reduce(
+            (result, item, index) => {
+                if (item) {
+                    result[item.label] = item.value;
+                }
+                return result;
+            },
+            {}
+        );
+        return {
+            "workItemId": workItemId,
+            "workItemUrl": workItemUrl,
+            ...fieldsAndValuesAsObject
+        };
+    };
+    let workItemData = getWorkItemData();
+    console.log(workItemData);
+    // TODO: Get similar work items via AzDO query URL
+    // TODO: Offer link to unit page per URL property
+
+    //     return {
+    //         msAuthorMetaTagValue: msAuthor,
+    //         gitHubAuthorMetaTagValue: author,
+    //         msDateMetaTagValue: msDate,
+    //         gitHubYamlLocation: gitUrlValues.gitYamlEditUrl,
+    //         gitHubMarkdownLocation: gitUrlValues.gitMarkdownEditUrl,
+    //     };
+    // };
+    // let cachePageMetadata = async function (location, pageMetadata) {
+    //     pageMetadata = getCurrentPageMetadata();
+    //     let cacheAddition = {};
+    //     cacheAddition[location] = pageMetadata;
+    //     await storageLocalSetAsync(cacheAddition);
+    // };
+    let sendUpdateRequest = function (workItemData) {
+        chrome.runtime.sendMessage(
+            {
+                method: 'workItemCollected',
+                data: workItemData
+            },
+            function (response) {
+                if (!response || !response.result) {
+                    console.log(`DEBUG: 'workItemCollected' sent message result was invalid: ${response}`);
+                }
+                else {
+                    console.log(`Work item data handled: ${response.result}`);
+                }
+            }
+        );
+    };
+
+    // let workItemId = document.location.href;
+
+    // var pageMetadata = await (async function () {
+    //     var cachedMetadata = await storageLocalGetAsync([ location ]);
+    //     return cachedMetadata[location];
+    // })();
+    // var wasPageMetadataCached = false;
+
+    // if (!pageMetadata) {
+    //     pageMetadata = getCurrentPageMetadata();
+    //     cachePageMetadata(location, pageMetadata);
+    // }
+    // else {
+    //     wasPageMetadataCached = true;
+    // }
+
+    sendUpdateRequest(workItemData);
+
+    // if (wasPageMetadataCached) {
+    //     // Get the latest from the page and re-cache it.
+    //     await delay(5000);
+    //     pageMetadata = getCurrentPageMetadata();
+    //     cachePageMetadata(location, pageMetadata);
+    //     sendUpdateRequest(pageMetadata);
+    // }
+})();

--- a/azure-devops-extension-popup.html
+++ b/azure-devops-extension-popup.html
@@ -6,15 +6,13 @@
     <script defer src="/js/all.min.js"></script>
 </head>
 <body>
-    <table>
+    <table style="width: 250px">
         <tr>
-            <td>UID</td><td><span class="copy-field-target" id="uid">...</span></td><td><button class="copy-field-btn fas fa-clipboard"></button></td>
+            <!-- TODO: swap to a field or styling where we can shorten the display of lengthy UIDs. (Then remove width style above.) -->
+            <td>UID</td><td><a target="_blank" id="contentUrl"><span class="copy-field-target" style="overflow: hidden;" id="uid">...</span></a></td><td><button class="copy-field-btn fas fa-clipboard"></button></td>
         </tr>
         <tr>
-            <td>ms.date</td><td><span id="msDate">...</span></td>
-        </tr>
-        <tr>
-            <td>repo URL</td><td><a target="_blank" id="repoUrlMarkdown">MD</a> (<a target="_blank" id="repoUrlYaml">YAML</a>)</td>
+            <td colspan="2"><a target="_blank" id="relatedWorkItemsQueryUrl">Related issues</a> (<a target="_blank" id="relatedVerbatimsQueryUrl">Verbatims</a>)</td>
         </tr>
     </table>
     <script src="azure-devops-extension-popup.js"></script>

--- a/azure-devops-extension-popup.html
+++ b/azure-devops-extension-popup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <style>
+    </style>
+    <script defer src="/js/all.min.js"></script>
+</head>
+<body>
+    <table>
+        <tr>
+            <td>UID</td><td><span class="copy-field-target" id="uid">...</span></td><td><button class="copy-field-btn fas fa-clipboard"></button></td>
+        </tr>
+        <tr>
+            <td>ms.date</td><td><span id="msDate">...</span></td>
+        </tr>
+        <tr>
+            <td>repo URL</td><td><a target="_blank" id="repoUrlMarkdown">MD</a> (<a target="_blank" id="repoUrlYaml">YAML</a>)</td>
+        </tr>
+    </table>
+    <script src="azure-devops-extension-popup.js"></script>
+</body>
+</html>

--- a/azure-devops-extension-popup.html
+++ b/azure-devops-extension-popup.html
@@ -9,7 +9,7 @@
     <table style="width: 250px">
         <tr>
             <!-- TODO: swap to a field or styling where we can shorten the display of lengthy UIDs. (Then remove width style above.) -->
-            <td>UID</td><td><a target="_blank" id="contentUrl"><span class="copy-field-target" style="overflow: hidden;" id="uid">...</span></a></td><td><button class="copy-field-btn fas fa-clipboard"></button></td>
+            <td>UID</td><td><a target="_blank" id="contentUrl"><span class="copy-field-target" style="overflow: hidden;" id="uid">...</span></a></td><td><button class="copy-field-btn"><span class="fas fa-clipboard"></span></button></td>
         </tr>
         <tr>
             <td colspan="2"><a target="_blank" id="relatedWorkItemsQueryUrl">Related issues</a> (<a target="_blank" id="relatedVerbatimsQueryUrl">Verbatims</a>)</td>

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -1,25 +1,44 @@
 // NOTE: This script executes in the context of the pop-up itself (vs. below, where we execute a script in the target tab).
 let uidSpan = document.getElementById("uid");
+let contentUrl = document.getElementById("contentUrl");
+let relatedFeedbackWorkItemsQueryUrl = document.getElementById("relatedWorkItemsQueryUrl");
+let relatedVerbatimsWorkItemsQueryUrl = document.getElementById("relatedVerbatimsQueryUrl");
 
 let displayWorkItemData = async function (workItemData) {
-    uidSpan.textContent = workItemData.uid;
-    // TODO: Offer link to get related work items (by UID or portion of UID)
-    // TODO: Offer link to work item URL
+    // TODO: Figure out why it doesn't display properly for module work items (e.g., https://ceapex.visualstudio.com/Microsoft%20Learn/_workitems/edit/51164).
+    if (workItemData.UID) {
+        /**
+         * @type {string}
+         */
+        const uid = workItemData.UID;
+        uidSpan.textContent = uid;
 
-    // if (workItemData.uid) {
-    //     let relatedItemsUrl = "";
-    //     // TODO: Build URL for ad hoc AzDO query to related items.
-    //     contentYamlGitUrlAnchor.setAttribute("href", relatedItemsUrl);
-    // }
-    // else {
-    //     contentYamlGitUrlAnchor.removeAttribute('href');
-    // }
-    // if (workItemData.gitHubMarkdownLocation) {
-    //     contentMarkdownGitUrlAnchor.setAttribute("href", workItemData.gitHubMarkdownLocation);
-    // }
-    // else {
-    //     contentMarkdownGitUrlAnchor.removeAttribute('href');
-    // }
+        // For related items, search for immediate UID and next level up
+        // e.g., learn.area.module.1-unit -> [ learn.area.module.1-unit, learn.area.module ]
+        let uidPeriodCount = uid.length - uid.replace(".", "").length;
+        let uidWithoutLastSection = uid.slice(0, uid.lastIndexOf("."));
+        let uidSubstrings = [uid, uidWithoutLastSection];
+        let uidQuery = `'${uidSubstrings.join("','")}'`;
+        let issueQuery = `SELECT [System.Id],[System.Title], [System.AssignedTo],[CEINTL.TriageStatus] FROM workitems WHERE [System.TeamProject]=@project AND [System.WorkItemType]='Customer Feedback' AND [System.State]='New' AND [Custom.UID] IN (${uidQuery}) AND [Custom.FeedbackSource]='Report an issue'`;
+        let uidMatchIssuesQuery = `https://ceapex.visualstudio.com/Microsoft%20Learn/_queries/query/?wiql=${encodeURIComponent(issueQuery)}`;
+        relatedFeedbackWorkItemsQueryUrl.setAttribute("href", uidMatchIssuesQuery);
+        let verbatimQuery = `SELECT [System.Id],[System.Title], [System.AssignedTo],[CEINTL.TriageStatus] FROM workitems WHERE [System.TeamProject]=@project AND [System.WorkItemType]='Customer Feedback' AND [System.State]='New' AND [Custom.UID] IN (${uidQuery}) AND [Custom.FeedbackSource]='Star rating verbatim'`;
+        let uidMatchVerbatimQuery = `https://ceapex.visualstudio.com/Microsoft%20Learn/_queries/query/?wiql=${encodeURIComponent(verbatimQuery)}`;
+        relatedFeedbackWorkItemsQueryUrl.setAttribute("href", uidMatchIssuesQuery);
+        relatedVerbatimsWorkItemsQueryUrl.setAttribute("href", uidMatchVerbatimQuery);
+    }
+    else {
+        uidSpan.textContent = "<not found>";
+        relatedFeedbackWorkItemsQueryUrl.removeAttribute("href");
+        relatedVerbatimsWorkItemsQueryUrl.removeAttribute("href");
+    }
+
+    if (workItemData.URL) {
+        contentUrl.setAttribute("href", workItemData.URL);
+    }
+    else {
+        contentUrl.removeAttribute('href');
+    }
 };
 
 chrome.runtime.onMessage.addListener(async function (request, sender, sendResponse) {

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -30,7 +30,7 @@ let displayWorkItemData = async function (workItemData) {
         relatedVerbatimsWorkItemsQueryUrl.setAttribute("href", uidMatchVerbatimQuery);
     }
     else {
-        uidSpan.textContent = "<not found>";
+        uidSpan.textContent = "<no work item found>";
         relatedFeedbackWorkItemsQueryUrl.removeAttribute("href");
         relatedVerbatimsWorkItemsQueryUrl.removeAttribute("href");
     }

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -4,6 +4,18 @@ let contentUrl = document.getElementById("contentUrl");
 let relatedFeedbackWorkItemsQueryUrl = document.getElementById("relatedWorkItemsQueryUrl");
 let relatedVerbatimsWorkItemsQueryUrl = document.getElementById("relatedVerbatimsQueryUrl");
 
+let copyButtons = [...document.getElementsByClassName("copy-field-btn")];
+copyButtons.forEach(btn => {
+    btn.onclick = async function(element) {
+        // Find nearest sibling `.copy-field-target` and copying its text to clipboard.
+        let siblingCopyTargets = [...btn.parentNode.parentNode.getElementsByClassName("copy-field-target")];
+        let copyTarget = siblingCopyTargets && siblingCopyTargets[0];
+        let copyValue = copyTarget && copyTarget.innerText;
+        // NOTE: Catching error because it will throw a DOMException ("Document is not focused.") whenever the window isn't focused and we try to copy to clipboard (e.g., debugging in dev tools).
+        await navigator.clipboard.writeText(copyValue).catch(error => console.log("Error while trying to copy to clipboard", error));
+    };
+});
+
 let displayWorkItemData = async function (workItemData) {
     // TODO: Figure out why it doesn't display properly for module work items (e.g., https://ceapex.visualstudio.com/Microsoft%20Learn/_workitems/edit/51164).
     if (workItemData.UID) {
@@ -47,18 +59,6 @@ chrome.runtime.onMessage.addListener(async function (request, sender, sendRespon
     switch (request.method) {
         case "workItemCollected":
             await displayWorkItemData(request.data);
-
-            let copyButtons = [...document.getElementsByClassName("copy-field-btn")];
-            copyButtons.forEach(btn => {
-                btn.onclick = async function(element) {
-                    // Find nearest sibling `.copy-field-target` and copying its text to clipboard.
-                    let siblingCopyTargets = [...btn.parentNode.parentNode.getElementsByClassName("copy-field-target")];
-                    let copyTarget = siblingCopyTargets && siblingCopyTargets[0];
-                    let copyValue = copyTarget && copyTarget.innerText;
-                    // NOTE: Catching error because it will throw a DOMException ("Document is not focused.") whenever the window isn't focused and we try to copy to clipboard (e.g., debugging in dev tools).
-                    await navigator.clipboard.writeText(copyValue).catch(error => console.log("Error while trying to copy to clipboard", error));
-                };
-            });
 
             sendResponse(
                 {

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -19,10 +19,12 @@ let displayWorkItemData = async function (workItemData) {
         let uidWithoutLastSection = uid.slice(0, uid.lastIndexOf("."));
         let uidSubstrings = [uid, uidWithoutLastSection];
         let uidQuery = `'${uidSubstrings.join("','")}'`;
-        let issueQuery = `SELECT [System.Id],[System.Title], [System.AssignedTo],[CEINTL.TriageStatus] FROM workitems WHERE [System.TeamProject]=@project AND [System.WorkItemType]='Customer Feedback' AND [System.State]='New' AND [Custom.UID] IN (${uidQuery}) AND [Custom.FeedbackSource]='Report an issue'`;
+        let issueQuery = `SELECT [System.Id],[Title],[Severity],[Created Date],[Work Item Type],[Assigned To],[Triage Status],[Feedback Type],[UID],[URL],[Repo MSFT Learn] FROM workitems WHERE [Team Project] = @project AND [Work Item Type] = 'Customer Feedback' AND [State] = 'New'
+        AND [UID] IN (${uidQuery}) AND [Feedback Source]='Report an issue' ORDER BY [UID], [Severity]`;
         let uidMatchIssuesQuery = `https://ceapex.visualstudio.com/Microsoft%20Learn/_queries/query/?wiql=${encodeURIComponent(issueQuery)}`;
         relatedFeedbackWorkItemsQueryUrl.setAttribute("href", uidMatchIssuesQuery);
-        let verbatimQuery = `SELECT [System.Id],[System.Title], [System.AssignedTo],[CEINTL.TriageStatus] FROM workitems WHERE [System.TeamProject]=@project AND [System.WorkItemType]='Customer Feedback' AND [System.State]='New' AND [Custom.UID] IN (${uidQuery}) AND [Custom.FeedbackSource]='Star rating verbatim'`;
+        let verbatimQuery = `SELECT [System.Id],[Title],[Severity],[Created Date],[Work Item Type],[Assigned To],[Triage Status],[Feedback Type],[UID],[URL],[Repo MSFT Learn] FROM workitems WHERE [Team Project] = @project AND [Work Item Type] = 'Customer Feedback' AND [State] = 'New'
+        AND [UID] IN (${uidQuery}) AND [Feedback Source]='Star rating verbatim' ORDER BY [UID], [Severity]`;
         let uidMatchVerbatimQuery = `https://ceapex.visualstudio.com/Microsoft%20Learn/_queries/query/?wiql=${encodeURIComponent(verbatimQuery)}`;
         relatedFeedbackWorkItemsQueryUrl.setAttribute("href", uidMatchIssuesQuery);
         relatedVerbatimsWorkItemsQueryUrl.setAttribute("href", uidMatchVerbatimQuery);

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -1,0 +1,70 @@
+// NOTE: This script executes in the context of the pop-up itself (vs. below, where we execute a script in the target tab).
+let uidSpan = document.getElementById("uid");
+
+let displayWorkItemData = async function (workItemData) {
+    uidSpan.textContent = workItemData.uid;
+    // TODO: Offer link to get related work items (by UID or portion of UID)
+    // TODO: Offer link to work item URL
+
+    // if (workItemData.uid) {
+    //     let relatedItemsUrl = "";
+    //     // TODO: Build URL for ad hoc AzDO query to related items.
+    //     contentYamlGitUrlAnchor.setAttribute("href", relatedItemsUrl);
+    // }
+    // else {
+    //     contentYamlGitUrlAnchor.removeAttribute('href');
+    // }
+    // if (workItemData.gitHubMarkdownLocation) {
+    //     contentMarkdownGitUrlAnchor.setAttribute("href", workItemData.gitHubMarkdownLocation);
+    // }
+    // else {
+    //     contentMarkdownGitUrlAnchor.removeAttribute('href');
+    // }
+};
+
+chrome.runtime.onMessage.addListener(async function (request, sender, sendResponse) {
+    switch (request.method) {
+        case "workItemCollected":
+            await displayWorkItemData(request.data);
+
+            let copyButtons = [...document.getElementsByClassName("copy-field-btn")];
+            copyButtons.forEach(btn => {
+                btn.onclick = async function(element) {
+                    // Find nearest sibling `.copy-field-target` and copying its text to clipboard.
+                    let siblingCopyTargets = [...btn.parentNode.parentNode.getElementsByClassName("copy-field-target")];
+                    let copyTarget = siblingCopyTargets && siblingCopyTargets[0];
+                    let copyValue = copyTarget && copyTarget.innerText;
+                    // NOTE: Catching error because it will throw a DOMException ("Document is not focused.") whenever the window isn't focused and we try to copy to clipboard (e.g., debugging in dev tools).
+                    await navigator.clipboard.writeText(copyValue).catch(error => console.log("Error while trying to copy to clipboard", error));
+                };
+            });
+
+            sendResponse(
+                {
+                    result: "success"
+                }
+            );
+            break;
+    }
+});
+
+// Have pop-up execute a script in the current tab.
+chrome.tabs.query({ active: true, currentWindow: true },
+    function(tabs) {
+        // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+        const azureDevOpsPageScript = "azdo-helpers.js";
+        let tempAnchor = document.createElement("a");
+        tempAnchor.href = tabs[0].url;
+        let tabId = tabs[0].id;
+        // TODO: Remove logging after figuring out the structure of tabs and each tab item.
+        console.log({ tab0: tabs[0], tabs: tabs, hostname: tempAnchor.hostname });
+        if (tempAnchor.hostname.endsWith("visualstudio.com")) {
+            chrome.tabs.executeScript(
+                tabId,
+                {
+                    file: azureDevOpsPageScript
+                }
+            );
+        }
+    }
+);

--- a/background.js
+++ b/background.js
@@ -1,3 +1,24 @@
+let setPopUpFromCurrentTab = function (tabId) {
+    chrome.tabs.get(tabId, function (tab) {
+        // NOTE: This system manually duplicates a lot of what is being done in background.js PageStateMatcher system. There is probably a better way.
+        let tabId = tab.id;
+        let tempAnchor = document.createElement("a");
+        tempAnchor.href = tab.url;
+        let host = tempAnchor.hostname;
+        if (host.endsWith("docs.microsoft.com")) {
+            chrome.browserAction.setPopup({
+                tabId: tabId,
+                popup: "learn-extension-popup.html"
+            });
+        }
+        else if (host.endsWith("visualstudio.com")) {
+            chrome.browserAction.setPopup({
+                tabId: tabId,
+                popup: "azure-devops-extension-popup.html"
+            });
+        }
+    });
+}
 chrome.runtime.onInstalled.addListener(function() {
     chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
         // TODO: Find out if conditions in the array are AND or OR. If OR, we can combine them both (possible example evidence for OR: https://github.com/kudos/combine.fm/blob/8ea8b4d279bf411064cf1328710e8a343fe021d5/chrome/src/background.js#L5-L42).
@@ -34,171 +55,21 @@ chrome.runtime.onInstalled.addListener(function() {
                     // NOTE: These calls may fire immediately after the extension is loaded, not when deciding when to show something on a given tab. (Maybe they only fire when an applicable tab is already open???)
                     return new chrome.declarativeContent.ShowPageAction();
                 })()]
-                // NOTE: Lots of attempts to work with this `actions` system didn't work.
-                // actions: [(() => {
-                //     // NOTE: These calls may fire immediately after the extension is loaded (possibly only if you have an applicable tab open already).
-                //     // FAIL: browserAction not defined?
-                //     chrome.browserAction.setPopup({
-                //         popup: "azure-devops-extension-popup.html"
-                //     });
-                //     return new chrome.declarativeContent.ShowPageAction();
-                // })()]
-                // let doThing = function () {
-                //     console.log("Made it!!!");
-                //     new chrome.declarativeContent.ShowPageAction();
-                // };
-                // actions: [
-                //     doThing()
-                //     // new chrome.declarativeContent.ShowPageAction()
-                // ]
-                // actions: [
-                //     console.log("hola!!!"),
-                //     new chrome.declarativeContent.ShowPageAction()
-                // ]
-                // actions: [(() => {
-                //     new chrome.declarativeContent.ShowPageAction();
-                // })()]
-                // actions: [(function () {
-                //     new chrome.declarativeContent.ShowPageAction();
-                // })()]
             }
         ]);
 
         // NOTE: chrome.browserAction is still saying it doesn't have setPopup. Maybe it's not available yet?
         chrome.tabs.onActivated.addListener(function (activeInfo) {
             // window.alert(`tab activated (ID: ${activeInfo.tabId}, windowId: ${activeInfo.windowId})`);
-            chrome.tabs.get(activeInfo.tabId, function (tab) {
-                // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
-                let tabId = tab.id;
-                let tempAnchor = document.createElement("a");
-                tempAnchor.href = tab.url;
-                let host = tempAnchor.hostname;
-                // TODO: Remove logging after figuring out the structure of tabs and each tab item.
-                // window.alert(`tab grabbed (url: ${tab.url},\n host: ${host})`);
-                if (host.endsWith("docs.microsoft.com")) {
-                    chrome.browserAction.setPopup({
-                        tabId: tabId,
-                        popup: "learn-extension-popup.html"
-                    });
-                }
-                else if (host.endsWith("visualstudio.com")) {
-                    chrome.browserAction.setPopup({
-                        tabId: tabId,
-                        popup: "azure-devops-extension-popup.html"
-                    });
-                }
-            });
+            setPopUpFromCurrentTab(activeInfo.tabId);
         });
+        // Set the pop-up for the first run of things. After this, the `onActivated` should do the work of keeping it maintained.
+        chrome.tabs.query({ active: true, currentWindow: true },
+            function(tabs) {
+                let tabId = tabs[0].id;
+                setPopUpFromCurrentTab(tabId);
+            }
+        );
+        // TODO: Add a default pop-up that isn't set for a page, in case we haven't run anything yet.
     });
 });
-
-// NOTE: chrome.browserAction is still saying it doesn't have setPopup. Maybe it's not available yet?
-// chrome.tabs.onActivated.addListener(function (activeInfo) {
-//     window.alert(`tab activated (ID: ${activeInfo.tabId}, windowId: ${activeInfo.windowId})`);
-//     chrome.tabs.get(activeInfo.tabId, function (tab) {
-//         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
-//         let tabId = tab.id;
-//         let tempAnchor = document.createElement("a");
-//         tempAnchor.href = tab.url;
-//         let host = tempAnchor.hostname;
-//         // TODO: Remove logging after figuring out the structure of tabs and each tab item.
-//         window.alert(`tab grabbed (url: ${tab.url},\n host: ${host})`);
-//         if (host.endsWith("docs.microsoft.com")) {
-//             chrome.browserAction.setPopup({
-//                 tabId: tabId,
-//                 popup: "learn-extension-popup.html"
-//             }, () => { window.alert("docs setPopup callback!"); });
-//         }
-//         else if (host.endsWith("visualstudio.com")) {
-//             chrome.browserAction.setPopup({
-//                 tabId: tabId,
-//                 popup: "azure-devops-extension-popup.html"
-//             }, function () { window.alert("azdo setPopup callback!"); });
-//         }
-//     });
-//     // This query wasn't always returning the activated tab (but sometimes it was).
-//     // chrome.tabs.query({ active: true, currentWindow: true },
-//     //     function(tabs) {
-//     //         window.alert("tab query started");
-//     //         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
-//     //         const firstTab = tabs[0];
-//     //         let tabId = firstTab.id;
-//     //         let tempAnchor = document.createElement("a");
-//     //         tempAnchor.href = firstTab.url;
-//     //         // TODO: Remove logging after figuring out the structure of tabs and each tab item.
-//     //         window.alert(`host: ${tempAnchor.hostname}`);
-//     //         console.log({ firstTab, tabs, hostname: tempAnchor.hostname });
-//     //         if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
-//     //             chrome.browserAction.setPopup({
-//     //                 tabId: tabId,
-//     //                 popup: "learn-extension-popup.html"
-//     //             }, () => { window.alert("docs setPopup callback!"); });
-//     //         }
-//     //         else if (tempAnchor.hostname.endsWith("visualstudio.com")) {
-//     //             chrome.browserAction.setPopup({
-//     //                 tabId: tabId,
-//     //                 popup: "azure-devops-extension-popup.html"
-//     //             }, function () { window.alert("azdo setPopup callback!"); });
-//     //         }
-//     //     }
-//     // );
-// });
-
-// chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
-//     // NOTE: `onUpdated` fires for several events in the tabs lifetime. Sometimes, the current URL is available at `tab.url || tab.pendingUrl || changeInfo.url`, but sometimes note. (For some reason, I got a URL when I would refresh a Learn page but not on an AzDO page.) We could try tying to `onCreated` or `onActivated` instead. I worry that `onCreated` may not help with any existing tabs when the extension is installed/loaded/refreshed.
-//     // NOTE: There is probably a more reliable way to do a `setPopup` call, but I don't know it yet.
-
-//     // Set the pop-up content based on the current tab: one for Learn/Docs pages, one for Azure DevOps pages.
-
-//     console.log({ status: changeInfo.status, changeInfo })
-//     if (changeInfo.status === "complete") {
-//         let url = tab.url || tab.pendingUrl || changeInfo.url;
-//         // window.alert(`tab updated: ${changeInfo.status} (${url})!`);
-//         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
-//         // window.alert(`logging:\ntabId: ${tabId}, tab: ${tab} (url: ${tab.url}), changeInfo: ${changeInfo} (${changeInfo.url}, ${changeInfo.status})`);
-//         console.log({ tabId, tab, changeInfo });
-//         // if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
-//         //     chrome.browserAction.setPopup({
-//         //         tabId: tabId,
-//         //         popup: "learn-extension-popup.html"
-//         //     }, () => { window.alert("docs setPopup callback!"); });
-//         // }
-//         // else if (tempAnchor.hostname.endsWith("visualstudio.com")) {
-//         //     chrome.browserAction.setPopup({
-//         //         tabId: tabId,
-//         //         popup: "azure-devops-extension-popup.html"
-//         //     }, function () { window.alert("azdo setPopup callback!"); });
-//         // }
-//     }
-
-
-//     // let setPopUpHtml = function () {
-//     //     // Set the pop-up content based on the current tab: one for Learn/Docs pages, one for Azure DevOps pages.
-//     //     chrome.tabs.query({ active: true, currentWindow: true },
-//     //         function(tabs) {
-//     //             window.alert("tab query started");
-//     //             // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
-//     //             const firstTab = tabs[0];
-//     //             let tempAnchor = document.createElement("a");
-//     //             // TODO: Remove logging after figuring out the structure of tabs and each tab item.
-//     //             window.alert(`host: ${tempAnchor.hostname}`);
-//     //             console.log({ tab0: firstTab, tabs: tabs, hostname: tempAnchor.hostname });
-//     //             tempAnchor.href = firstTab.url;
-//     //             let tabId = firstTab.id;
-//     //             if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
-//     //                 chrome.browserAction.setPopup({
-//     //                     tabId: tabId,
-//     //                     popup: "learn-extension-popup.html"
-//     //                 }, () => { window.alert("docs setPopup callback!"); });
-//     //             }
-//     //             else if (tempAnchor.hostname.endsWith("visualstudio.com")) {
-//     //                 chrome.browserAction.setPopup({
-//     //                     tabId: tabId,
-//     //                     popup: "azure-devops-extension-popup.html"
-//     //                 }, function () { window.alert("azdo setPopup callback!"); });
-//     //             }
-//     //         }
-//     //     );
-//     // };
-//     // setPopUpHtml();
-// });

--- a/background.js
+++ b/background.js
@@ -1,20 +1,204 @@
 chrome.runtime.onInstalled.addListener(function() {
     chrome.declarativeContent.onPageChanged.removeRules(undefined, function() {
-        chrome.declarativeContent.onPageChanged.addRules([{
-            conditions: [
-                new chrome.declarativeContent.PageStateMatcher({
-                    pageUrl: {
-                        // We are hoping to allow this extension whenever we can. That includes the following URL examples.
-                        // * Microsoft Docs: https://docs.microsoft.com/en-us/xamarin/essentials/platform-feature-support?context=xamarin/android
-                        // * Microsoft Learn (modules, units): https://docs.microsoft.com/en-us/learn/modules/welcome-to-azure/2-what-is-azure
-                        // * Microsoft Learn Docs: https://review.docs.microsoft.com/learn-docs/docs/support-triage-issues
-                        // Not super specific here, but may be good enough (other options: https://developer.chrome.com/extensions/declarativeContent#type-PageStateMatcher).
-                        // We could make a bunch of nearly identical rules for these or catch more than intended and handle edge cases elsewhere in code. So far, we are choosing the later.
-                        hostSuffix: "docs.microsoft.com",
-                    },
-                })
-            ],
-            actions: [new chrome.declarativeContent.ShowPageAction()]
-        }]);
+        // TODO: Find out if conditions in the array are AND or OR. If OR, we can combine them both (possible example evidence for OR: https://github.com/kudos/combine.fm/blob/8ea8b4d279bf411064cf1328710e8a343fe021d5/chrome/src/background.js#L5-L42).
+        chrome.declarativeContent.onPageChanged.addRules([
+            {
+                conditions: [
+                    new chrome.declarativeContent.PageStateMatcher({
+                        pageUrl: {
+                            // We are hoping to allow this extension whenever we can. That includes the following URL examples.
+                            // * Microsoft Docs: https://docs.microsoft.com/en-us/xamarin/essentials/platform-feature-support?context=xamarin/android
+                            // * Microsoft Learn (modules, units): https://docs.microsoft.com/en-us/learn/modules/welcome-to-azure/2-what-is-azure
+                            // * Microsoft Learn Docs: https://review.docs.microsoft.com/learn-docs/docs/support-triage-issues
+                            // Not super specific here, but may be good enough (other options: https://developer.chrome.com/extensions/declarativeContent#type-PageStateMatcher).
+                            // We could make a bunch of nearly identical rules for these or catch more than intended and handle edge cases elsewhere in code. So far, we are choosing the later.
+                            hostSuffix: "docs.microsoft.com",
+                        },
+                    })
+                ],
+                actions: [new chrome.declarativeContent.ShowPageAction()]
+            },
+            {
+                conditions: [
+                    new chrome.declarativeContent.PageStateMatcher({
+                        pageUrl: {
+                            // We are hoping to allow this extension whenever we can. That includes the following URL examples.
+                            // * Azure DevOps: https://*.visualstudio.com/
+                            // Not super specific here, but may be good enough (other options: https://developer.chrome.com/extensions/declarativeContent#type-PageStateMatcher).
+                            // We could make a bunch of nearly identical rules for these or catch more than intended and handle edge cases elsewhere in code. So far, we are choosing the later.
+                            hostSuffix: "visualstudio.com",
+                        },
+                    })
+                ],
+                actions: [(() => {
+                    // NOTE: These calls may fire immediately after the extension is loaded, not when deciding when to show something on a given tab. (Maybe they only fire when an applicable tab is already open???)
+                    return new chrome.declarativeContent.ShowPageAction();
+                })()]
+                // NOTE: Lots of attempts to work with this `actions` system didn't work.
+                // actions: [(() => {
+                //     // NOTE: These calls may fire immediately after the extension is loaded (possibly only if you have an applicable tab open already).
+                //     // FAIL: browserAction not defined?
+                //     chrome.browserAction.setPopup({
+                //         popup: "azure-devops-extension-popup.html"
+                //     });
+                //     return new chrome.declarativeContent.ShowPageAction();
+                // })()]
+                // let doThing = function () {
+                //     console.log("Made it!!!");
+                //     new chrome.declarativeContent.ShowPageAction();
+                // };
+                // actions: [
+                //     doThing()
+                //     // new chrome.declarativeContent.ShowPageAction()
+                // ]
+                // actions: [
+                //     console.log("hola!!!"),
+                //     new chrome.declarativeContent.ShowPageAction()
+                // ]
+                // actions: [(() => {
+                //     new chrome.declarativeContent.ShowPageAction();
+                // })()]
+                // actions: [(function () {
+                //     new chrome.declarativeContent.ShowPageAction();
+                // })()]
+            }
+        ]);
+
+        // NOTE: chrome.browserAction is still saying it doesn't have setPopup. Maybe it's not available yet?
+        chrome.tabs.onActivated.addListener(function (activeInfo) {
+            // window.alert(`tab activated (ID: ${activeInfo.tabId}, windowId: ${activeInfo.windowId})`);
+            chrome.tabs.get(activeInfo.tabId, function (tab) {
+                // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+                let tabId = tab.id;
+                let tempAnchor = document.createElement("a");
+                tempAnchor.href = tab.url;
+                let host = tempAnchor.hostname;
+                // TODO: Remove logging after figuring out the structure of tabs and each tab item.
+                // window.alert(`tab grabbed (url: ${tab.url},\n host: ${host})`);
+                if (host.endsWith("docs.microsoft.com")) {
+                    chrome.browserAction.setPopup({
+                        tabId: tabId,
+                        popup: "learn-extension-popup.html"
+                    });
+                }
+                else if (host.endsWith("visualstudio.com")) {
+                    chrome.browserAction.setPopup({
+                        tabId: tabId,
+                        popup: "azure-devops-extension-popup.html"
+                    });
+                }
+            });
+        });
     });
 });
+
+// NOTE: chrome.browserAction is still saying it doesn't have setPopup. Maybe it's not available yet?
+// chrome.tabs.onActivated.addListener(function (activeInfo) {
+//     window.alert(`tab activated (ID: ${activeInfo.tabId}, windowId: ${activeInfo.windowId})`);
+//     chrome.tabs.get(activeInfo.tabId, function (tab) {
+//         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+//         let tabId = tab.id;
+//         let tempAnchor = document.createElement("a");
+//         tempAnchor.href = tab.url;
+//         let host = tempAnchor.hostname;
+//         // TODO: Remove logging after figuring out the structure of tabs and each tab item.
+//         window.alert(`tab grabbed (url: ${tab.url},\n host: ${host})`);
+//         if (host.endsWith("docs.microsoft.com")) {
+//             chrome.browserAction.setPopup({
+//                 tabId: tabId,
+//                 popup: "learn-extension-popup.html"
+//             }, () => { window.alert("docs setPopup callback!"); });
+//         }
+//         else if (host.endsWith("visualstudio.com")) {
+//             chrome.browserAction.setPopup({
+//                 tabId: tabId,
+//                 popup: "azure-devops-extension-popup.html"
+//             }, function () { window.alert("azdo setPopup callback!"); });
+//         }
+//     });
+//     // This query wasn't always returning the activated tab (but sometimes it was).
+//     // chrome.tabs.query({ active: true, currentWindow: true },
+//     //     function(tabs) {
+//     //         window.alert("tab query started");
+//     //         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+//     //         const firstTab = tabs[0];
+//     //         let tabId = firstTab.id;
+//     //         let tempAnchor = document.createElement("a");
+//     //         tempAnchor.href = firstTab.url;
+//     //         // TODO: Remove logging after figuring out the structure of tabs and each tab item.
+//     //         window.alert(`host: ${tempAnchor.hostname}`);
+//     //         console.log({ firstTab, tabs, hostname: tempAnchor.hostname });
+//     //         if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
+//     //             chrome.browserAction.setPopup({
+//     //                 tabId: tabId,
+//     //                 popup: "learn-extension-popup.html"
+//     //             }, () => { window.alert("docs setPopup callback!"); });
+//     //         }
+//     //         else if (tempAnchor.hostname.endsWith("visualstudio.com")) {
+//     //             chrome.browserAction.setPopup({
+//     //                 tabId: tabId,
+//     //                 popup: "azure-devops-extension-popup.html"
+//     //             }, function () { window.alert("azdo setPopup callback!"); });
+//     //         }
+//     //     }
+//     // );
+// });
+
+// chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+//     // NOTE: `onUpdated` fires for several events in the tabs lifetime. Sometimes, the current URL is available at `tab.url || tab.pendingUrl || changeInfo.url`, but sometimes note. (For some reason, I got a URL when I would refresh a Learn page but not on an AzDO page.) We could try tying to `onCreated` or `onActivated` instead. I worry that `onCreated` may not help with any existing tabs when the extension is installed/loaded/refreshed.
+//     // NOTE: There is probably a more reliable way to do a `setPopup` call, but I don't know it yet.
+
+//     // Set the pop-up content based on the current tab: one for Learn/Docs pages, one for Azure DevOps pages.
+
+//     console.log({ status: changeInfo.status, changeInfo })
+//     if (changeInfo.status === "complete") {
+//         let url = tab.url || tab.pendingUrl || changeInfo.url;
+//         // window.alert(`tab updated: ${changeInfo.status} (${url})!`);
+//         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+//         // window.alert(`logging:\ntabId: ${tabId}, tab: ${tab} (url: ${tab.url}), changeInfo: ${changeInfo} (${changeInfo.url}, ${changeInfo.status})`);
+//         console.log({ tabId, tab, changeInfo });
+//         // if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
+//         //     chrome.browserAction.setPopup({
+//         //         tabId: tabId,
+//         //         popup: "learn-extension-popup.html"
+//         //     }, () => { window.alert("docs setPopup callback!"); });
+//         // }
+//         // else if (tempAnchor.hostname.endsWith("visualstudio.com")) {
+//         //     chrome.browserAction.setPopup({
+//         //         tabId: tabId,
+//         //         popup: "azure-devops-extension-popup.html"
+//         //     }, function () { window.alert("azdo setPopup callback!"); });
+//         // }
+//     }
+
+
+//     // let setPopUpHtml = function () {
+//     //     // Set the pop-up content based on the current tab: one for Learn/Docs pages, one for Azure DevOps pages.
+//     //     chrome.tabs.query({ active: true, currentWindow: true },
+//     //         function(tabs) {
+//     //             window.alert("tab query started");
+//     //             // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+//     //             const firstTab = tabs[0];
+//     //             let tempAnchor = document.createElement("a");
+//     //             // TODO: Remove logging after figuring out the structure of tabs and each tab item.
+//     //             window.alert(`host: ${tempAnchor.hostname}`);
+//     //             console.log({ tab0: firstTab, tabs: tabs, hostname: tempAnchor.hostname });
+//     //             tempAnchor.href = firstTab.url;
+//     //             let tabId = firstTab.id;
+//     //             if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
+//     //                 chrome.browserAction.setPopup({
+//     //                     tabId: tabId,
+//     //                     popup: "learn-extension-popup.html"
+//     //                 }, () => { window.alert("docs setPopup callback!"); });
+//     //             }
+//     //             else if (tempAnchor.hostname.endsWith("visualstudio.com")) {
+//     //                 chrome.browserAction.setPopup({
+//     //                     tabId: tabId,
+//     //                     popup: "azure-devops-extension-popup.html"
+//     //                 }, function () { window.alert("azdo setPopup callback!"); });
+//     //             }
+//     //         }
+//     //     );
+//     // };
+//     // setPopUpHtml();
+// });

--- a/background.js
+++ b/background.js
@@ -74,10 +74,16 @@ chrome.runtime.onInstalled.addListener(function() {
             }
         ]);
 
-        // TODO: This still might not handle navigation from a page without a work item to a page that has a work item.
+        // NOTE: This handles when you switch between tabs to readdress which pop-up is shown.
         chrome.tabs.onActivated.addListener(function (activeInfo) {
-            // window.alert(`tab activated (ID: ${activeInfo.tabId}, windowId: ${activeInfo.windowId})`);
             setPopUpByTabId(activeInfo.tabId);
+        });
+        // NOTE: This handles when you navigate between pages _within_ a tab to readdress which pop-up is shown. (Sometimes, if a page didn't need a pop-up and you navigated to one that should have a pop-up, it wasn't being shown.)
+        chrome.tabs.onUpdated.addListener(function (tabId, changeInfo, tab) {
+            // This gets called a lot! Restrict to only onUpdated calls where the URL in the tab was changed.
+            if (changeInfo.url) {
+                setPopUpByTabId(tabId);
+            }
         });
         // TODO: Add a default pop-up that isn't set for a page, in case we haven't run anything yet.
     });

--- a/docs-extension-popup.js
+++ b/docs-extension-popup.js
@@ -1,4 +1,4 @@
-let gatherMetadataButton = document.getElementById("gatherMetadata");
+// NOTE: This script executes in the context of the pop-up itself (vs. below, where we execute a script in the target tab).
 let msAuthorSpan = document.getElementById("msAuthor");
 let gitHubAuthorSpan = document.getElementById("gitHubAuthor");
 let msDateSpan = document.getElementById("msDate");
@@ -50,13 +50,23 @@ chrome.runtime.onMessage.addListener(async function (request, sender, sendRespon
     }
 });
 
+// Execute a script in the current tab.
 chrome.tabs.query({ active: true, currentWindow: true },
     function(tabs) {
-        chrome.tabs.executeScript(
-            tabs[0].id,
-            {
-                file: "get-author.js"
-            }
-        );
+        // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
+        const microsoftLearnPageScript = "get-author.js";
+        let tempAnchor = document.createElement("a");
+        tempAnchor.href = tabs[0].url;
+        let tabId = tabs[0].id;
+        // TODO: Remove logging after figuring out the structure of tabs and each tab item.
+        console.log({ tab0: tabs[0], tabs: tabs, hostname: tempAnchor.hostname });
+        if (tempAnchor.hostname.endsWith("docs.microsoft.com")) {
+            chrome.tabs.executeScript(
+                tabId,
+                {
+                    file: microsoftLearnPageScript
+                }
+            );
+        }
     }
 );

--- a/docs-extension-popup.js
+++ b/docs-extension-popup.js
@@ -5,6 +5,18 @@ let msDateSpan = document.getElementById("msDate");
 let contentYamlGitUrlAnchor = document.getElementById("repoUrlYaml");
 let contentMarkdownGitUrlAnchor = document.getElementById("repoUrlMarkdown");
 
+let copyButtons = [...document.getElementsByClassName("copy-field-btn")];
+copyButtons.forEach(btn => {
+    btn.onclick = async function(element) {
+        // Find nearest sibling `.copy-field-target` and copying its text to clipboard.
+        let siblingCopyTargets = [...btn.parentNode.parentNode.getElementsByClassName("copy-field-target")];
+        let copyTarget = siblingCopyTargets && siblingCopyTargets[0];
+        let copyValue = copyTarget && copyTarget.innerText;
+        // NOTE: Catching error because it will throw a DOMException ("Document is not focused.") whenever the window isn't focused and we try to copy to clipboard (e.g., debugging in dev tools).
+        await navigator.clipboard.writeText(copyValue).catch(error => console.log("Error while trying to copy to clipboard", error));
+    };
+});
+
 let displayMetadata = async function (metadata) {
     msAuthorSpan.textContent = metadata.msAuthorMetaTagValue;
     gitHubAuthorSpan.textContent = metadata.gitHubAuthorMetaTagValue;
@@ -28,18 +40,6 @@ chrome.runtime.onMessage.addListener(async function (request, sender, sendRespon
     switch (request.method) {
         case "metadataCollected":
             await displayMetadata(request.data);
-
-            let copyButtons = [...document.getElementsByClassName("copy-field-btn")];
-            copyButtons.forEach(btn => {
-                btn.onclick = async function(element) {
-                    // Find nearest sibling `.copy-field-target` and copying its text to clipboard.
-                    let siblingCopyTargets = [...btn.parentNode.parentNode.getElementsByClassName("copy-field-target")];
-                    let copyTarget = siblingCopyTargets && siblingCopyTargets[0];
-                    let copyValue = copyTarget && copyTarget.innerText;
-                    // NOTE: Catching error because it will throw a DOMException ("Document is not focused.") whenever the window isn't focused and we try to copy to clipboard (e.g., debugging in dev tools).
-                    await navigator.clipboard.writeText(copyValue).catch(error => console.log("Error while trying to copy to clipboard", error));
-                };
-            });
 
             sendResponse(
                 {

--- a/get-author.js
+++ b/get-author.js
@@ -111,12 +111,12 @@
         };
     };
     let cachePageMetadata = async function (location, pageMetadata) {
-        pageMetadata = getCurrentPageMetadata();
+        // ???pageMetadata = getCurrentPageMetadata();
         let cacheAddition = {};
         cacheAddition[location] = pageMetadata;
         await storageLocalSetAsync(cacheAddition);
     };
-    let sendUpdateRequest = function (pageMetadata) {
+    let sendPopUpUpdateRequest = function (pageMetadata) {
         chrome.runtime.sendMessage(
             {
                 method: 'metadataCollected',
@@ -135,12 +135,14 @@
 
     let location = document.location.href;
 
+    // Try to get cached metadata as a placeholder.
     var pageMetadata = await (async function () {
         var cachedMetadata = await storageLocalGetAsync([ location ]);
         return cachedMetadata[location];
     })();
     var wasPageMetadataCached = false;
 
+    // If no cached data, get current.
     if (!pageMetadata) {
         pageMetadata = getCurrentPageMetadata();
         cachePageMetadata(location, pageMetadata);
@@ -149,13 +151,13 @@
         wasPageMetadataCached = true;
     }
 
-    sendUpdateRequest(pageMetadata);
+    sendPopUpUpdateRequest(pageMetadata);
 
+    // If we used cached metadata, get the latest and update the cache.
     if (wasPageMetadataCached) {
-        // Get the latest from the page and re-cache it.
         await delay(5000);
         pageMetadata = getCurrentPageMetadata();
         cachePageMetadata(location, pageMetadata);
-        sendUpdateRequest(pageMetadata);
+        sendPopUpUpdateRequest(pageMetadata);
     }
 })();

--- a/learn-extension-popup.html
+++ b/learn-extension-popup.html
@@ -8,10 +8,10 @@
 <body>
     <table>
         <tr>
-            <td>ms.author</td><td><span class="copy-field-target" id="msAuthor">...</span></td><td><button class="copy-field-btn fas fa-clipboard"></button></td>
+            <td>ms.author</td><td><span class="copy-field-target" id="msAuthor">...</span></td><td><button class="copy-field-btn"><span class="fas fa-clipboard"></span></button></td>
         </tr>
         <tr>
-            <td>author</td><td><span id="gitHubAuthor" class="copy-field-target">...</span></td><td><button class="copy-field-btn fas fa-clipboard"></button></td>
+            <td>author</td><td><span id="gitHubAuthor" class="copy-field-target">...</span></td><td><button class="copy-field-btn"><span class="fas fa-clipboard"></span></button></td>
         </tr>
         <tr>
             <td>ms.date</td><td><span id="msDate">...</span></td>

--- a/learn-extension-popup.html
+++ b/learn-extension-popup.html
@@ -20,6 +20,6 @@
             <td>repo URL</td><td><a target="_blank" id="repoUrlMarkdown">MD</a> (<a target="_blank" id="repoUrlYaml">YAML</a>)</td>
         </tr>
     </table>
-    <script src="extension-popup.js"></script>
+    <script src="docs-extension-popup.js"></script>
 </body>
 </html>

--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,9 @@
   "description": "Helping you maintain content on Microsoft Learn and Docs. Extract metadata from content pages for editing or triage purposes.",
   "version": "0.4.0",
   "permissions": [
+    // TODO: Research a match pattern instead of `activeTab` (per note in developer dashboard permission justifcation section): https://developer.chrome.com/extensions/match_patterns
     "activeTab",
+    "tabs",
     "declarativeContent",
     "storage"
   ],
@@ -14,8 +16,10 @@
     ],
     "persistent": false
   },
-  "page_action": {
-    "default_popup": "extension-popup.html",
+  // Switched from `page_action` to `browser_action` to get `chrome.browserAction.setPopup` to be defined in code. Previously had everything working fine in `page_action`, but now I have no idea why.
+  // It feels like I should be able to do page_actions for each domain or something, but haven't figured that out (per docs: https://developer.chrome.com/extensions/browserAction#tips).
+  "browser_action": {
+    "default_popup": "learn-extension-popup.html",
     "default_icon": {
       "16": "images/learn-tool16.png",
       "32": "images/learn-tool32.png",


### PR DESCRIPTION
## Features

Loads a unique pop-up when viewing Learn-centric Azure DevOps work items. (#10)

- [x] Ability to load reported Learn content page from link
- [x] Ability to load a query of related customer feedback issues
- [x] Ability to load a query of related customer feedback verbatims

## Extras

- [x] Rename content scripts for better context (#15)
- [x] Fix clipboard not copying anymore (AzDO and Learn) (#18)
- [x] Copy-to-clipboard button handlers no longer part of messaging system (more reliable)
