### PR TITLE
Learn pop-up: offer UID

### DIFF
--- a/docs-extension-popup.js
+++ b/docs-extension-popup.js
@@ -1,4 +1,5 @@
 // NOTE: This script executes in the context of the pop-up itself (vs. below, where we execute a script in the target tab).
+let uidSpan = document.querySelector("#uid");
 let msAuthorSpan = document.getElementById("msAuthor");
 let gitHubAuthorSpan = document.getElementById("gitHubAuthor");
 let msDateSpan = document.getElementById("msDate");
@@ -18,6 +19,7 @@ copyButtons.forEach(btn => {
 });
 
 let displayMetadata = async function (metadata) {
+    uidSpan.textContent = metadata.uid;
     msAuthorSpan.textContent = metadata.msAuthorMetaTagValue;
     gitHubAuthorSpan.textContent = metadata.gitHubAuthorMetaTagValue;
     msDateSpan.textContent = metadata.msDateMetaTagValue;

--- a/get-docs-metadata.js
+++ b/get-docs-metadata.js
@@ -65,6 +65,8 @@
     // storageLocalRemoveAsync([ location ]);
     let getCurrentPageMetadata = function () {
         let metaTags = document.getElementsByTagName("meta");
+        let uidTag = [...metaTags].filter(meta => meta.getAttribute("name") === "uid")[0];
+        let uid = uidTag ? uidTag.getAttribute("content") : "";
         let msAuthorTag = [...metaTags].filter(meta => meta.getAttribute("name") === "ms.author")[0];
         let msAuthor = msAuthorTag ? msAuthorTag.getAttribute("content") : "";
         let authorTag = [...metaTags].filter(meta => meta.getAttribute("name") === "author")[0];
@@ -103,6 +105,7 @@
         })(metaTags);
 
         return {
+            uid,
             msAuthorMetaTagValue: msAuthor,
             gitHubAuthorMetaTagValue: author,
             msDateMetaTagValue: msDate,

--- a/learn-extension-popup.html
+++ b/learn-extension-popup.html
@@ -14,6 +14,9 @@
             <td>author</td><td><span id="gitHubAuthor" class="copy-field-target">...</span></td><td><button class="copy-field-btn"><span class="fas fa-clipboard"></span></button></td>
         </tr>
         <tr>
+            <td>UID</td><td><span id="uid" class="copy-field-target">...</span></td><td><button class="copy-field-btn"><span class="fas fa-clipboard"></span></button></td>
+        </tr>
+        <tr>
             <td>ms.date</td><td><span id="msDate">...</span></td>
         </tr>
         <tr>


### PR DESCRIPTION
{Fixes #21}

Example screenshot:
![Screenshot of Learn maintenance tool showing UID in the Learn page pop-up with a copy button available.](https://user-images.githubusercontent.com/713665/84043707-e1995400-a963-11ea-9bc4-8e7d1988bc2c.png)
