### PR TITLE
Remove caching

### DIFF
--- a/get-docs-metadata.js
+++ b/get-docs-metadata.js
@@ -1,67 +1,5 @@
 // NOTE: Had to stuff everything in this immediately executing function to avoid duplicate declaration errors when this script was run every time the pop-up was loaded. Probably a better way to handle this, though.
 (async function () {
-    function delay(ms) {
-        return new Promise(resolve => setTimeout(resolve, ms));
-    }
-    let storageLocalGetAsync = function (keys) {
-        // TODO: Add some sort of expiration logic to set/get.
-        let gotValue = new Promise((resolve, reject) => {
-            chrome.storage.local.get(
-                keys, // NOTE: `null` will get entire contents of storage
-                function (result) {
-                    // Keys could be a string or an array of strings (or any object to get back an empty result, or null to get all of cache).
-                    // Unify to an array regardless.
-                    let keyList = Array.isArray(keys) ? [...keys] : [keys];
-                    for (var keyIndex in keyList) {
-                        var key = keyList[keyIndex];
-                        if (result[key]) {
-                            console.log({status: `Cache found: [${key}]`, keys, result });
-                        }
-                        else {
-                            console.log({status: `Cache miss: [${key}]`, keys });
-                        }
-                    }
-                    resolve(result);
-                }
-            );
-        });
-        return gotValue;
-    };
-    let storageLocalSetAsync = function (items) {
-        // TODO: Add some sort of expiration logic to set/get.
-        let setValue = new Promise((resolve, reject) => {
-            chrome.storage.local.set(
-                items,
-                function () {
-                    // If this cache call fails, Chrome will have set `runtime.lastError`.
-                    if (chrome.runtime.lastError) {
-                        reject(new Error(chrome.runtime.lastError.message || `Cache set error: ${chrome.runtime.lastError}`));
-                    }
-                    else {
-                        resolve();
-                    }
-                }
-            );
-        });
-        return setValue;
-    };
-    let storageLocalRemoveAsync = async function (keys) {
-        let removeValue = new Promise((resolve, reject) => {
-            chrome.storage.local.remove(
-                keys,
-                function () {
-                    // If this cache call fails, Chrome will have set `runtime.lastError`.
-                    if (chrome.runtime.lastError) {
-                        reject(new Error(chrome.runtime.lastError.message || `Error retrieving cache: ${chrome.runtime.lastError}`));
-                    }
-                    else {
-                        resolve();
-                    }
-                }
-            );
-        });
-    };
-    
     // storageLocalRemoveAsync([ location ]);
     let getCurrentPageMetadata = function () {
         let metaTags = document.getElementsByTagName("meta");
@@ -98,7 +36,7 @@
                 let gitMarkdownEditUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
                 let gitYamlEditUrl = null; // ?not applicable outside Learn?
                 return {
-                    gitYamlEditUrl: null,
+                    gitYamlEditUrl,
                     gitMarkdownEditUrl
                 };
             }
@@ -112,12 +50,6 @@
             gitHubYamlLocation: gitUrlValues.gitYamlEditUrl,
             gitHubMarkdownLocation: gitUrlValues.gitMarkdownEditUrl,
         };
-    };
-    let cachePageMetadata = async function (location, pageMetadata) {
-        // ???pageMetadata = getCurrentPageMetadata();
-        let cacheAddition = {};
-        cacheAddition[location] = pageMetadata;
-        await storageLocalSetAsync(cacheAddition);
     };
     let sendPopUpUpdateRequest = function (pageMetadata) {
         chrome.runtime.sendMessage(
@@ -136,31 +68,6 @@
         );
     };
 
-    let location = document.location.href;
-
-    // Try to get cached metadata as a placeholder.
-    var pageMetadata = await (async function () {
-        var cachedMetadata = await storageLocalGetAsync([ location ]);
-        return cachedMetadata[location];
-    })();
-    var wasPageMetadataCached = false;
-
-    // If no cached data, get current.
-    if (!pageMetadata) {
-        pageMetadata = getCurrentPageMetadata();
-        cachePageMetadata(location, pageMetadata);
-    }
-    else {
-        wasPageMetadataCached = true;
-    }
-
+    var pageMetadata = getCurrentPageMetadata();
     sendPopUpUpdateRequest(pageMetadata);
-
-    // If we used cached metadata, get the latest and update the cache.
-    if (wasPageMetadataCached) {
-        await delay(5000);
-        pageMetadata = getCurrentPageMetadata();
-        cachePageMetadata(location, pageMetadata);
-        sendPopUpUpdateRequest(pageMetadata);
-    }
 })();


### PR DESCRIPTION
This was added without much thought at the time, and never made it to Azure DevOps page scraping. So removing until it is deemed necessary. At that point, we can add it to all pages properly, and maybe with a proper expiration system.