### PR TITLE
Handle changed Learn metadata fields (fixes #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ For Microsoft Edge, you'll first need to allow installing extensions from other 
 
 ## Release notes
 
-### v0.6.0:
+### v0.7
+
+* [v0.7.0] While on an Azure DevOps customer feedback work item, extract metadata from the target content page when the extension is activated
+* [v0.7.0] Extract UID from module work items
+* [v0.7.1] Azure DevOps: Handle when multiple work item structures exist in page HTML (#40)
+* [v0.7.1] Related work item query now only excludes star rating verbatims (#42)
+* [v0.7.2] Fix for missing Markdown edit link after Learn switched metadata fields (#45)
+
+### v0.6
 
 * Allow use on Azure DevOps from alternate domain: dev.azure.com/{team}/{project}
 * Offer UID when gathering metadata for Learn content pages
@@ -67,8 +75,9 @@ For Microsoft Edge, you'll first need to allow installing extensions from other 
 
 Here are the current plans for upcoming releases. These are definitely subject to change as this project develops or evolves.
 
-### v0.7+: Customization
+### v0.8+: Customization
 
+* Offer a customizable URL to take you to an Azure DevOps query of your choice
 * Allow customizing which metadata fields are important to you
 
 ### Future plans and suggestions

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -91,35 +91,33 @@ let getCurrentPageMetadata = function (rootElement) {
     let msDateTag = [...metaTags].filter(meta => meta.getAttribute("name") === "ms.date")[0];
     let msDate = msDateTag ? msDateTag.getAttribute("content") : "";
     let gitUrlValues = (function (metaTags) {
-        // Learn uses `original_ref_skeleton_git_url` while Docs pages use `original_content_git_url`.
-        let gitUrlTag = [...metaTags].filter(meta => meta.getAttribute("name") === "original_ref_skeleton_git_url")[0];
-        // e.g., <meta name="original_ref_skeleton_git_url" content="https://github.com/MicrosoftDocs/learn-pr/blob/live/learn-pr/azure/welcome-to-azure/2-what-is-azure.yml" />
-        // Edit location is for a .yml (YAML) file on the live branch. We switch to master branch manually (where edits are made), and swap for .md for Markdown content.
-
-        if (gitUrlTag !== undefined) {
-            let gitUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
-            let gitYamlMasterUrl = gitUrl.replace("/live/", "/master/");
-            let gitMarkdownMasterUrl = gitYamlMasterUrl.endsWith("/index.yml")
-                ? gitYamlMasterUrl
-                : [ ...gitYamlMasterUrl.split("/").slice(0, -1), "includes", gitYamlMasterUrl.split("/").slice(-1)[0].replace("yml", "md") ].join("/");
-            return {
-                gitYamlEditUrl: gitYamlMasterUrl,
-                gitMarkdownEditUrl: gitMarkdownMasterUrl
-            };
+        // Learn stopped using `original_ref_skeleton_git_url`, likely to align with greater-Docs, so everywhere seems to be using `original_content_git_url` now.
+        let gitUrlTag = [...metaTags].filter(meta => meta.getAttribute("name") === "original_content_git_url")[0];
+        // e.g., <meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/learn-docs/blob/master/learn-docs/docs/support-triage-issues.md" />
+        let gitUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
+        // Switch from the publish branch to the primary branch. This may require updating as we switch to a branch named main in the future.
+        let gitEditUrl = gitUrl.replace("/live/", "/master/");
+        let gitYamlEditUrl = null;
+        let gitMarkdownEditUrl = null;
+        if (gitEditUrl.endsWith("/index.yml")) {
+            // Learn has index pages that are generated entirely from a YAML page.
+            gitYamlEditUrl = gitEditUrl;
+            gitMarkdownEditUrl = null;
+        }
+        else if (gitEditUrl.endsWith(".yml")) {
+            // Learn has other pages with both YAML and MD content contributing to the final HTML output.
+            gitYamlEditUrl = gitEditUrl;
+            gitMarkdownEditUrl = [ ...gitEditUrl.split("/").slice(0, -1), "includes", gitEditUrl.split("/").slice(-1)[0].replace("yml", "md") ].join("/");
         }
         else {
-            let gitUrlTag = [...metaTags].filter(meta => meta.getAttribute("name") === "original_content_git_url")[0];
-            // e.g., <meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/learn-docs/blob/master/learn-docs/docs/support-triage-issues.md" />
-            // Use the raw URL for Markdown edit location. (YAML edit location doesn't exist.)
-            
-            let gitMarkdownEditUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
-            let gitMarkdownMasterEditUrl = gitMarkdownEditUrl.replace("/live/", "/master/");
-            let gitYamlEditUrl = null; // ?not applicable outside Learn?
-            return {
-                gitYamlEditUrl,
-                gitMarkdownEditUrl: gitMarkdownMasterEditUrl
-            };
+            // Most of Docs has content and metadata entirely in a Markdown file.
+            gitYamlEditUrl = null;
+            gitMarkdownEditUrl = gitEditUrl;
         }
+        return {
+            gitYamlEditUrl,
+            gitMarkdownEditUrl
+        };
     })(metaTags);
 
     return {

--- a/get-docs-metadata.js
+++ b/get-docs-metadata.js
@@ -12,35 +12,33 @@
         let msDateTag = [...metaTags].filter(meta => meta.getAttribute("name") === "ms.date")[0];
         let msDate = msDateTag ? msDateTag.getAttribute("content") : "";
         let gitUrlValues = (function (metaTags) {
-            // Learn uses `original_ref_skeleton_git_url` while Docs pages use `original_content_git_url`.
-            let gitUrlTag = [...metaTags].filter(meta => meta.getAttribute("name") === "original_ref_skeleton_git_url")[0];
-            // e.g., <meta name="original_ref_skeleton_git_url" content="https://github.com/MicrosoftDocs/learn-pr/blob/live/learn-pr/azure/welcome-to-azure/2-what-is-azure.yml" />
-            // Edit location is for a .yml (YAML) file on the live branch. We switch to master branch manually (where edits are made), and swap for .md for Markdown content.
-
-            if (gitUrlTag !== undefined) {
-                let gitUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
-                let gitYamlMasterUrl = gitUrl.replace("/live/", "/master/");
-                let gitMarkdownMasterUrl = gitYamlMasterUrl.endsWith("/index.yml")
-                    ? gitYamlMasterUrl
-                    : [ ...gitYamlMasterUrl.split("/").slice(0, -1), "includes", gitYamlMasterUrl.split("/").slice(-1)[0].replace("yml", "md") ].join("/");
-                return {
-                    gitYamlEditUrl: gitYamlMasterUrl,
-                    gitMarkdownEditUrl: gitMarkdownMasterUrl
-                };
+            // Learn stopped using `original_ref_skeleton_git_url`, likely to align with greater-Docs, so everywhere seems to be using `original_content_git_url` now.
+            let gitUrlTag = [...metaTags].filter(meta => meta.getAttribute("name") === "original_content_git_url")[0];
+            // e.g., <meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/learn-docs/blob/master/learn-docs/docs/support-triage-issues.md" />
+            let gitUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
+            // Switch from the publish branch to the primary branch. This may require updating as we switch to a branch named main in the future.
+            let gitEditUrl = gitUrl.replace("/live/", "/master/");
+            let gitYamlEditUrl = null;
+            let gitMarkdownEditUrl = null;
+            if (gitEditUrl.endsWith("/index.yml")) {
+                // Learn has index pages that are generated entirely from a YAML page.
+                gitYamlEditUrl = gitEditUrl;
+                gitMarkdownEditUrl = null;
+            }
+            else if (gitEditUrl.endsWith(".yml")) {
+                // Learn has other pages with both YAML and MD content contributing to the final HTML output.
+                gitYamlEditUrl = gitEditUrl;
+                gitMarkdownEditUrl = [ ...gitEditUrl.split("/").slice(0, -1), "includes", gitEditUrl.split("/").slice(-1)[0].replace("yml", "md") ].join("/");
             }
             else {
-                let gitUrlTag = [...metaTags].filter(meta => meta.getAttribute("name") === "original_content_git_url")[0];
-                // e.g., <meta name="original_content_git_url" content="https://github.com/MicrosoftDocs/learn-docs/blob/master/learn-docs/docs/support-triage-issues.md" />
-                // Use the raw URL for Markdown edit location. (YAML edit location doesn't exist.)
-                
-                let gitMarkdownEditUrl = gitUrlTag ? gitUrlTag.getAttribute("content") : "";
-                let gitMarkdownMasterEditUrl = gitMarkdownEditUrl.replace("/live/", "/master/");
-                let gitYamlEditUrl = null; // ?not applicable outside Learn?
-                return {
-                    gitYamlEditUrl,
-                    gitMarkdownEditUrl: gitMarkdownMasterEditUrl
-                };
+                // Most of Docs has content and metadata entirely in a Markdown file.
+                gitYamlEditUrl = null;
+                gitMarkdownEditUrl = gitEditUrl;
             }
+            return {
+                gitYamlEditUrl,
+                gitMarkdownEditUrl
+            };
         })(metaTags);
 
         return {

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Microsoft Learn maintenance tool",
   "short_name": "LearnTool",
   "description": "Helping you maintain content on Microsoft Learn and Docs. Extract useful metadata quickly for editing or triage purposes.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "permissions": [
     "activeTab",
     "tabs",


### PR DESCRIPTION
Handles unified metadata field names now that Learn has moved away from `original_ref_skeleton_git_url` to `original_content_git_url` for the source content location.