### PR TITLE
Adjustments to work item query URLs

### DIFF
--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -39,18 +39,26 @@ let displayWorkItemData = async function (workItemData) {
         uidSpan.textContent = uid;
         uidSpan.title = uid;
 
-        // For related items, search for immediate UID and next level up
+        // For related items, search for immediate UID and also the next level up.
         // e.g., learn.area.module.1-unit -> [ learn.area.module.1-unit, learn.area.module ]
-        //let uidPeriodCount = uid.length - uid.replace(".", "").length;
-        let uidWithoutLastSection = uid.slice(0, uid.lastIndexOf("."));
-        let uidSubstrings = [uid, uidWithoutLastSection];
+        // NOTE: Not all modules follow the standard of unit UID construction, limiting the usefulness of these searches.
+        const uidPeriodCount = (uid.split(".").length - 1);
+        let uidSubstrings = [uid];
+        if (uidPeriodCount >= 2) {
+            let uidWithoutLastSection = uid.slice(0, uid.lastIndexOf("."));
+            uidSubstrings.push(uidWithoutLastSection);
+        }
+        let uidContainsQueryPortion = uidSubstrings.map(uidSubstring => `[UID] CONTAINS '${uidSubstring}'`).join(" OR ");
+        console.log(uidContainsQueryPortion);
         let uidQuery = `'${uidSubstrings.join("','")}'`;
         let issueQuery = `SELECT [System.Id],[Title],[Severity],[Created Date],[Work Item Type],[Assigned To],[Triage Status],[Feedback Type],[UID],[URL],[Repo MSFT Learn] FROM workitems WHERE [Team Project] = @project AND [Work Item Type] = 'Customer Feedback' AND [State] = 'New'
-        AND [UID] IN (${uidQuery}) AND [Feedback Source]<>'Star rating verbatim' ORDER BY [UID], [Severity]`;
+        AND (${uidContainsQueryPortion}) AND [Feedback Source]<>'Star rating verbatim' ORDER BY [UID], [Severity]`;
+        console.log(issueQuery);
         let uidMatchIssuesQuery = `https://ceapex.visualstudio.com/Microsoft%20Learn/_queries/query/?wiql=${encodeURIComponent(issueQuery)}`;
         relatedFeedbackWorkItemsQueryUrl.setAttribute("href", uidMatchIssuesQuery);
         let verbatimQuery = `SELECT [System.Id],[Title],[Severity],[Created Date],[Work Item Type],[Assigned To],[Triage Status],[Feedback Type],[UID],[URL],[Repo MSFT Learn] FROM workitems WHERE [Team Project] = @project AND [Work Item Type] = 'Customer Feedback' AND [State] = 'New'
-        AND [UID] IN (${uidQuery}) AND [Feedback Source]='Star rating verbatim' ORDER BY [UID], [Severity]`;
+        AND (${uidContainsQueryPortion}) AND [Feedback Source]='Star rating verbatim' ORDER BY [UID], [Severity]`;
+        console.log(issueQuery);
         let uidMatchVerbatimQuery = `https://ceapex.visualstudio.com/Microsoft%20Learn/_queries/query/?wiql=${encodeURIComponent(verbatimQuery)}`;
         relatedFeedbackWorkItemsQueryUrl.setAttribute("href", uidMatchIssuesQuery);
         relatedVerbatimsWorkItemsQueryUrl.setAttribute("href", uidMatchVerbatimQuery);


### PR DESCRIPTION
The prior `IN ({uid-fragments})` logic wasn't getting most of the relevant work items. This expands the scope using slightly adjusted logic and `CONTAINS` clauses, though at the expense of potential false positives. Those false positives should be something you can filter out manually via the resulting query and/or UID sorting.

{Fixes #73}