### PR TITLE
Manifest v3 update

### DIFF
--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -290,10 +290,10 @@ chrome.tabs.query({ active: true, currentWindow: true },
         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
         const azureDevOpsPageScript = "azdo-helpers.js";
         let activeTab = tabs[0];
-        let tempAnchor = document.createElement("a");
-        tempAnchor.href = activeTab.url;
+        let tabUrl = activeTab.url;
+        let tabUrlHostUrl = new URL(tabUrl);
+        let host = tabUrlHostUrl.hostname;
         let tabId = activeTab.id;
-        let host = tempAnchor.hostname;
         if (host.endsWith("visualstudio.com") || host === "dev.azure.com") {
             chrome.tabs.executeScript(
                 tabId,

--- a/azure-devops-extension-popup.js
+++ b/azure-devops-extension-popup.js
@@ -295,12 +295,10 @@ chrome.tabs.query({ active: true, currentWindow: true },
         let host = tabUrlHostUrl.hostname;
         let tabId = activeTab.id;
         if (host.endsWith("visualstudio.com") || host === "dev.azure.com") {
-            chrome.tabs.executeScript(
-                tabId,
-                {
-                    file: azureDevOpsPageScript
-                }
-            );
+            chrome.scripting.executeScript({
+                target: { tabId },
+                files: [ azureDevOpsPageScript ]
+            });
         }
     }
 );

--- a/background.js
+++ b/background.js
@@ -19,13 +19,13 @@ let setPopUpByTabId = function (tabId) {
         let tabUrlHostUrl = new URL(tabUrl);
         let host = tabUrlHostUrl.hostname;
         if (host.endsWith("learn.microsoft.com")) {
-            chrome.browserAction.setPopup({
+            chrome.action.setPopup({
                 tabId: tabId,
                 popup: "docs-extension-popup.html"
             });
         }
         else if (host.endsWith("visualstudio.com") || host === "dev.azure.com") {
-            chrome.browserAction.setPopup({
+            chrome.action.setPopup({
                 tabId: tabId,
                 popup: "azure-devops-extension-popup.html"
             });

--- a/background.js
+++ b/background.js
@@ -16,9 +16,8 @@ let setPopUpByTabId = function (tabId) {
         let tabId = tab.id;
         let tabUrl = tab.url;
 
-        let tempAnchor = document.createElement("a");
-        tempAnchor.href = tabUrl;
-        let host = tempAnchor.hostname;
+        let tabUrlHostUrl = new URL(tabUrl);
+        let host = tabUrlHostUrl.hostname;
         if (host.endsWith("learn.microsoft.com")) {
             chrome.browserAction.setPopup({
                 tabId: tabId,

--- a/docs-extension-popup.js
+++ b/docs-extension-popup.js
@@ -103,16 +103,11 @@ chrome.tabs.query({ active: true, currentWindow: true },
         // NOTE: This system duplicates a lot of the background.js PageStateMatcher system manually. There is probably a better way.
         const microsoftLearnPageScript = "get-docs-metadata.js";
         let activeTab = tabs[0];
-        let tempAnchor = document.createElement("a");
-        tempAnchor.href = activeTab.url;
+        let tabUrl = activeTab.url;
+        let tabUrlHostUrl = new URL(tabUrl);
+        let host = tabUrlHostUrl.hostname;
         let tabId = activeTab.id;
-        if (tempAnchor.hostname.endsWith("learn.microsoft.com")) {
-            chrome.tabs.executeScript(
-                tabId,
-                {
-                    file: microsoftLearnPageScript
-                }
-            );
+        if (host.endsWith("learn.microsoft.com")) {
         }
     }
 );

--- a/docs-extension-popup.js
+++ b/docs-extension-popup.js
@@ -108,6 +108,10 @@ chrome.tabs.query({ active: true, currentWindow: true },
         let host = tabUrlHostUrl.hostname;
         let tabId = activeTab.id;
         if (host.endsWith("learn.microsoft.com")) {
+            chrome.scripting.executeScript({
+                target: { tabId },
+                files: [ microsoftLearnPageScript ]
+            });
         }
     }
 );

--- a/manifest.json
+++ b/manifest.json
@@ -2,23 +2,23 @@
   "name": "Microsoft Learn maintenance tool",
   "short_name": "LearnTool",
   "description": "Helping you maintain content on Microsoft Learn and Docs. Extract useful metadata quickly for editing or triage purposes.",
-  "version": "0.7.8",
+  "version": "0.7.10",
   "permissions": [
     "activeTab",
     "tabs",
     "declarativeContent",
     "storage",
+    "scripting"
+  ],
+  "host_permissions": [
     "*://*.docs.microsoft.com/*",
     "*://*.learn.microsoft.com/*"
   ],
   "options_page": "options.html",
   "background": {
-    "scripts": [
-      "background.js"
-    ],
-    "persistent": false
+    "service_worker": "background.js"
   },
-  "browser_action": {
+  "action": {
     "default_popup": "docs-extension-popup.html",
     "default_icon": {
       "16": "images/learn-tool16.png",
@@ -33,5 +33,5 @@
     "48": "images/learn-tool48.png",
     "128": "images/learn-tool128.png"
   },
-  "manifest_version": 2
+  "manifest_version": 3
 }


### PR DESCRIPTION
While there is a manifest v2 version submitted that includes the fix for Learn rebrand changes, it may be rejected for being v2.

This updates to using v3 going forward. There was a prior effort to update while also improving some of the code architecture, but this is _just_ the v3 update alone for simplicity.